### PR TITLE
Fixes sinewave example on 0.10 (Stream API changes)

### DIFF
--- a/examples/sine.js
+++ b/examples/sine.js
@@ -30,7 +30,7 @@ sine._read = read;
 sine.pipe(new Speaker());
 
 // the Readable "_read()" callback function
-function read (n, fn) {
+function read (n) {
   var sampleSize = this.bitDepth / 8;
   var blockAlign = sampleSize * this.channels;
   var numSamples = n / blockAlign | 0;
@@ -51,7 +51,7 @@ function read (n, fn) {
     }
   }
 
-  fn(null, buf);
+  this.push(buf);
 
   this.samplesGenerated += numSamples;
   if (this.samplesGenerated >= this.sampleRate * duration) {


### PR DESCRIPTION
I noticed that the sine.js example was broken because stream.Readable works on pushes rather than continuations. Just a minor fix to get it working again.
