### PR TITLE
Adds support for JS to configure ring-buffer size.

### DIFF
--- a/deps/mpg123/src/audio.h
+++ b/deps/mpg123/src/audio.h
@@ -58,6 +58,8 @@ typedef struct audio_output_struct
 	long gain;		/* output gain */
 	int channels;	/* number of channels */
 	int format;		/* format flags */
+	int bufferSize; /* Size of each audio buffer to keep ahead */
+	int numBuffers; /* Number of audio buffers to keep ahead */
 	int is_open;	/* something opened? */
 #define MPG123_OUT_QUIET 1
 	int auxflags; /* For now just one: quiet mode (for probing). */

--- a/index.js
+++ b/index.js
@@ -147,6 +147,15 @@ Speaker.prototype._open = function () {
     debug('setting default %o: %o', 'signed', this.bitDepth != 8);
     this.signed = this.bitDepth != 8;
   }
+  if (null == this.bufferSize) {
+	debug('setting defualt %o: %o', 'bufferSize', 0x10000);
+	this.bufferSize = 0x10000;
+  }
+  
+  if (null == this.numBuffers) {
+	debug('setting default %o: %o', 'numBuffers', 8);
+	this.numBuffers = 8;
+  }
 
   var format = exports.getFormat(this);
   if (null == format) {
@@ -163,7 +172,7 @@ Speaker.prototype._open = function () {
   // initialize the audio handle
   // TODO: open async?
   this.audio_handle = new Buffer(binding.sizeof_audio_output_t);
-  var r = binding.open(this.audio_handle, this.channels, this.sampleRate, format);
+  var r = binding.open(this.audio_handle, this.channels, this.sampleRate, format, this.bufferSize, this.numBuffers);
   if (0 !== r) {
     throw new Error('open() failed: ' + r);
   }
@@ -202,6 +211,14 @@ Speaker.prototype._format = function (opts) {
   if (null != opts.signed) {
     debug('setting %o: %o', "signed", opts.signed);
     this.signed = opts.signed;
+  }
+  if (null != opts.bufferSize) {
+	debug('setting %o: %o', "bufferSize", opts.bufferSize);
+	this.bufferSize = opts.bufferSize;
+  }
+  if (null != opts.numBuffers) {
+	debug('setting %o: %o', "numBuffers", opts.numBuffers);
+	this.numBuffers = opts.numBuffers;
   }
   if (null != opts.samplesPerFrame) {
     debug('setting %o: %o', "samplesPerFrame", opts.samplesPerFrame);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -34,6 +34,8 @@ NAN_METHOD(Open) {
   ao->channels = args[1]->Int32Value(); /* channels */
   ao->rate = args[2]->Int32Value(); /* sample rate */
   ao->format = args[3]->Int32Value(); /* MPG123_ENC_* format */
+  ao->bufferSize = args[4]->Int32Value();
+  ao->numBuffers = args[5]->Int32Value();
 
   /* init_output() */
   r = mpg123_output_module_info.init_output(ao);
@@ -118,6 +120,8 @@ void Initialize(Handle<Object> target) {
   ao.channels = 2;
   ao.rate = 44100;
   ao.format = MPG123_ENC_SIGNED_16;
+  ao.numBuffers = 8;
+  ao.bufferSize = 0x10000;
   ao.open(&ao);
   target->Set(NanNew<v8::String>("formats"), NanNew<v8::Integer>(ao.get_formats(&ao)));
   ao.close(&ao);


### PR DESCRIPTION
The default buffer sizes chosen, at least in Win32, are extremely
conservative.  Sure, a skip in audio will be extremely rare, but for any
type of real-time application (video-games), the audio is near-unusable,
because sounds will play several seconds after the event that triggered
them.

I've exposed the buffer-size fields all the way up to the JS api, so
that the application developer can choose the best balance between
reliability and performance to fit their needs.  So far this is only
supported on Win32 (and ignored on other platforms), but I plan on
implementing additional platforms in the future.
