### PR TITLE
Sine example produces 220hz, not 440hz

### DIFF
--- a/examples/sine.js
+++ b/examples/sine.js
@@ -39,7 +39,7 @@ function read (n) {
 
   // the "angle" used in the function, adjusted for the number of
   // channels and sample rate. This value is like the period of the wave.
-  var t = (Math.PI * 2 * freq) / (this.sampleRate * this.channels);
+  var t = (Math.PI * 2 * freq) / this.sampleRate;
 
   for (var i = 0; i < numSamples; i++) {
     // fill with a simple sine wave at max amplitude


### PR DESCRIPTION
Tested by running the sine.js example, but the resulting tone sounds like 220hz, not 440hz as documented.

Changing the channels to 1 seems to correct the result, but any other value for the channel  generates a non-440hz tone. I don't think you need to divide the angle by the number of channels, however I'm unsure of this math.

Ref:
https://www.youtube.com/watch?v=OUvlamJN3nM 440hz tone
https://www.youtube.com/watch?v=82HaIjTq0yk 220hz tone
