### PR TITLE
link pulse and pulse-simple libraries when using mpg123 pulse backend

### DIFF
--- a/deps/mpg123/mpg123.gyp
+++ b/deps/mpg123/mpg123.gyp
@@ -218,6 +218,14 @@
             ],
           }
         }],
+        ['mpg123_backend=="pulse"', {
+          'link_settings': {
+            'libraries': [
+              '-lpulse',
+              '-lpulse-simple',
+            ],
+          }
+        }],
       ],
       'sources': [ 'src/output/<(mpg123_backend).c' ],
     },


### PR DESCRIPTION
The mpg123 pulse backend was missing some libraries

fixes TooTallNate/node-speaker#42