### PR TITLE
Fix compile with io.js 2.1.0 on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "bindings": "~1.2.1",
     "debug": "2",
-    "nan": "~1.7.0",
+    "nan": "^1.7.0",
     "readable-stream": "1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The nan dependency was specified as 1.7.0, but that is out of date for newer versions of io.js. Allowing npm to install newer versions fixes compile errors with newer io.js/V8.