### PR TITLE
Select audio device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /node_modules
 /build
 

--- a/index.js
+++ b/index.js
@@ -147,6 +147,10 @@ Speaker.prototype._open = function () {
     debug('setting default %o: %o', 'signed', this.bitDepth != 8);
     this.signed = this.bitDepth != 8;
   }
+  if (null == this.device) {
+    debug('setting default %o: %o', 'device', undefined);
+    this.device = undefined;
+  }
 
   var format = exports.getFormat(this);
   if (null == format) {
@@ -163,7 +167,7 @@ Speaker.prototype._open = function () {
   // initialize the audio handle
   // TODO: open async?
   this.audio_handle = new Buffer(binding.sizeof_audio_output_t);
-  var r = binding.open(this.audio_handle, this.channels, this.sampleRate, format);
+  var r = binding.open(this.audio_handle, this.channels, this.sampleRate, format, this.device);
   if (0 !== r) {
     throw new Error('open() failed: ' + r);
   }
@@ -206,6 +210,10 @@ Speaker.prototype._format = function (opts) {
   if (null != opts.samplesPerFrame) {
     debug('setting %o: %o', "samplesPerFrame", opts.samplesPerFrame);
     this.samplesPerFrame = opts.samplesPerFrame;
+  }
+  if (null != opts.device) {
+    debug('setting %o: %o', "device", opts.device);
+    this.device = opts.device;
   }
   if (null == opts.endianness || endianness == opts.endianness) {
     // no "endianness" specified or explicit native endianness

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -24,12 +24,21 @@ struct write_req {
 NAN_METHOD(Open) {
   Nan::EscapableHandleScope scope;
   int r;
+  char* device_argument;
+  v8::Local<v8::String> device_param;
+
   audio_output_t *ao = UnwrapPointer<audio_output_t *>(info[0]);
   memset(ao, 0, sizeof(audio_output_t));
 
   ao->channels = info[1]->Int32Value(); /* channels */
   ao->rate = info[2]->Int32Value(); /* sample rate */
   ao->format = info[3]->Int32Value(); /* MPG123_ENC_* format */
+
+  if (!info[4]->IsUndefined()) {
+    v8::String::Utf8Value device_param(info[4]->ToString());
+    device_argument = const_cast<char*> ( std::string(*device_param).c_str() );
+    ao->device = device_argument;
+  }
 
   /* init_output() */
   r = mpg123_output_module_info.init_output(ao);


### PR DESCRIPTION
Patch to allow the selection of the audio device via opts.device, which is then passed to mpeg123 (as `ao->device`).
