### PR TITLE
Adds more recent version of Node.js to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ node_js:
   - "2"
   - "3.2"
   - "4"
+  - "5"
+  - "6"
+  - "7"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"


### PR DESCRIPTION
This is a fairly dumb & easy one but I figured it would be best to keep up to date with the node versions...

(BTW, everything passes fine in the newer node.js versions.)