### PR TITLE
Add device option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ process.stdin.pipe(speaker);
 `require('speaker')` directly returns the `Speaker` constructor. It is the only
 interface exported by `node-speaker`.
 
-### new Speaker([ format ]) -> Speaker instance
+### new Speaker([ options ]) -> Speaker instance
 
 Creates a new `Speaker` instance, which is a writable stream that you can pipe
-PCM audio data to. The optional `format` object may contain any of the `Writable`
+PCM audio data to. The optional `options` object may contain any of the `Writable`
 base class options, as well as any of these PCM formatting options:
 
 * `channels` - The number of audio channels. PCM data must be interleaved. Defaults to `2`.
@@ -61,6 +61,7 @@ base class options, as well as any of these PCM formatting options:
 * `signed` - Boolean specifying if the samples are signed or unsigned. Defaults to `true` when bit depth is 8-bit, `false` otherwise.
 * `float` - Boolean specifying if the samples are floating-point values. Defaults to `false`.
 * `samplesPerFrame` - The number of samples to send to the audio backend at a time. You likely don't need to mess with this value. Defaults to `1024`.
+* `device` - The name of the playback device. E.g. `'hw:0,0'` for first device of first sound card or `'hw:1,0'` for first device of second sound card. Defaults to `null` which will pick the default device.
 
 #### "open" event
 

--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ class Speaker extends Writable {
       debug('setting default %o: %o', 'signed', this.bitDepth !== 8)
       this.signed = this.bitDepth !== 8
     }
+    if (this.device == null) {
+      debug('setting default %o: %o', 'device', null)
+      this.device = null
+    }
 
     const format = Speaker.getFormat(this)
     if (format == null) {
@@ -97,7 +101,7 @@ class Speaker extends Writable {
     // initialize the audio handle
     // TODO: open async?
     this.audio_handle = bufferAlloc(binding.sizeof_audio_output_t)
-    const r = binding.open(this.audio_handle, this.channels, this.sampleRate, format)
+    const r = binding.open(this.audio_handle, this.channels, this.sampleRate, format, this.device)
     if (r !== 0) {
       throw new Error(`open() failed: ${r}`)
     }
@@ -140,6 +144,10 @@ class Speaker extends Writable {
     if (opts.samplesPerFrame != null) {
       debug('setting %o: %o', 'samplesPerFrame', opts.samplesPerFrame)
       this.samplesPerFrame = opts.samplesPerFrame
+    }
+    if (opts.device != null) {
+      debug('setting %o: %o', 'device', opts.device)
+      this.device = opts.device
     }
     if (opts.endianness == null || endianness === opts.endianness) {
       // no "endianness" specified or explicit native endianness

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -31,6 +31,12 @@ NAN_METHOD(Open) {
   ao->rate = info[2]->Int32Value(); /* sample rate */
   ao->format = info[3]->Int32Value(); /* MPG123_ENC_* format */
 
+  if (info[4]->IsString()) {
+    v8::Local<v8::String> deviceString = info[4]->ToString();
+    ao->device = new char[deviceString->Length() + 1];
+    deviceString->WriteOneByte(reinterpret_cast<uint8_t *>(ao->device));
+  }
+
   /* init_output() */
   r = mpg123_output_module_info.init_output(ao);
   if (r == 0) {
@@ -98,6 +104,7 @@ NAN_METHOD(Close) {
   if (ao->deinit) {
     r = ao->deinit(ao);
   }
+  delete ao->device;
   info.GetReturnValue().Set(scope.Escape(Nan::New<v8::Integer>(r)));
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,15 @@ describe('Speaker', function () {
     done()
   })
 
+  it('should accept a device option', function (done) {
+    const s = new Speaker({ device: 'test' })
+
+    assert.equal(s.device, 'test')
+
+    s.on('close', done)
+    s.end(bufferAlloc(0))
+  })
+
   it('should not throw an Error if native "endianness" is specified', function () {
     assert.doesNotThrow(function () {
       // eslint-disable-next-line no-new


### PR DESCRIPTION
Same as #91 and #104 but with some improvements:

- handles `ao->device` lifecycle
- follows coding style
- with a minimal test

I haven't been able to test this myself yet since I'm only on macOS...

ping @meldron, @MexXxo, @T-vK, @rhclayto; would you mind testing if this works? ❤️ 