### PR TITLE
make node-speaker node10x compatible, use internal stream node module

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const os = require('os')
 const debug = require('debug')('speaker')
 const binding = require('bindings')('binding')
 const bufferAlloc = require('buffer-alloc')
-const Writable = require('readable-stream/writable')
+const Writable = require('stream').Writable
 
 // determine the native host endianness, the only supported playback endianness
 const endianness = os.endianness()

--- a/package.json
+++ b/package.json
@@ -10,14 +10,13 @@
   },
   "dependencies": {
     "bindings": "^1.3.0",
-    "buffer-alloc": "^1.1.0",
-    "debug": "^3.0.1",
-    "nan": "^2.6.2",
-    "readable-stream": "^2.3.3"
+    "buffer-alloc": "^1.2.0",
+    "debug": "^3.1.0",
+    "nan": "^2.11.0"
   },
   "devDependencies": {
-    "mocha": "^3.5.0",
-    "standard": "^10.0.3"
+    "mocha": "^5.2.0",
+    "standard": "^12.0.0"
   },
   "engines": {
     "node": ">4"

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -83,7 +83,8 @@ void write_after (uv_work_t *req) {
     Nan::New(wreq->written)
   };
 
-  wreq->callback->Call(1, argv);
+  // wreq->callback->Call(1, argv);
+  Nan::Call(*wreq->callback, 1, argv);
 
   delete wreq->callback;
 }
@@ -110,16 +111,16 @@ NAN_METHOD(Close) {
 
 void Initialize(Handle<Object> target) {
   Nan::HandleScope scope;
-  Nan::ForceSet(target,
+  Nan::DefineOwnProperty(target,
                 Nan::New("api_version").ToLocalChecked(),
                 Nan::New(mpg123_output_module_info.api_version));
-  Nan::ForceSet(target,
+  Nan::DefineOwnProperty(target,
                 Nan::New("name").ToLocalChecked(),
                 Nan::New(mpg123_output_module_info.name).ToLocalChecked());
-  Nan::ForceSet(target,
+  Nan::DefineOwnProperty(target,
                 Nan::New("description").ToLocalChecked(),
                 Nan::New(mpg123_output_module_info.description).ToLocalChecked());
-  Nan::ForceSet(target,
+  Nan::DefineOwnProperty(target,
                 Nan::New("revision").ToLocalChecked(),
                 Nan::New(mpg123_output_module_info.revision).ToLocalChecked());
 
@@ -130,14 +131,14 @@ void Initialize(Handle<Object> target) {
   ao.rate = 44100;
   ao.format = MPG123_ENC_SIGNED_16;
   ao.open(&ao);
-  Nan::ForceSet(target, Nan::New("formats").ToLocalChecked(), Nan::New(ao.get_formats(&ao)));
+  Nan::DefineOwnProperty(target, Nan::New("formats").ToLocalChecked(), Nan::New(ao.get_formats(&ao)));
   ao.close(&ao);
 
   target->Set(Nan::New("sizeof_audio_output_t").ToLocalChecked(),
               Nan::New(static_cast<uint32_t>(sizeof(audio_output_t))));
 
 #define CONST_INT(value) \
-  Nan::ForceSet(target, Nan::New(#value).ToLocalChecked(), Nan::New(value), \
+  Nan::DefineOwnProperty(target, Nan::New(#value).ToLocalChecked(), Nan::New(value), \
       static_cast<PropertyAttribute>(ReadOnly|DontDelete));
 
   CONST_INT(MPG123_ENC_FLOAT_32);

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ const opposite = endianness === 'LE' ? 'BE' : 'LE'
 
 describe('exports', function () {
   it('should export a Function', function () {
-    assert.equal('function', typeof Speaker)
+    assert.strict.equal('function', typeof Speaker)
   })
 
   it('should have an "api_version" property', function () {
@@ -43,8 +43,8 @@ describe('Speaker', function () {
 
   it('should be a writable stream', function () {
     const s = new Speaker()
-    assert.equal(s.writable, true)
-    assert.notEqual(s.readable, true)
+    assert.strict.equal(s.writable, true)
+    assert.strict.notEqual(s.readable, true)
   })
 
   it('should emit an "open" event after the first write()', function (done) {
@@ -54,7 +54,7 @@ describe('Speaker', function () {
       called = true
       done()
     })
-    assert.equal(called, false)
+    assert.strict.equal(called, false)
     s.write(bufferAlloc(0))
   })
 
@@ -65,7 +65,7 @@ describe('Speaker', function () {
       called = true
       done()
     })
-    assert.equal(called, false)
+    assert.strict.equal(called, false)
     s.end(bufferAlloc(0))
   })
 
@@ -77,7 +77,7 @@ describe('Speaker', function () {
       called = true
       done()
     })
-    assert.equal(called, false)
+    assert.strict.equal(called, false)
     s.end(bufferAlloc(0))
   })
 
@@ -87,18 +87,18 @@ describe('Speaker', function () {
     s.on('close', function () {
       count++
     })
-    assert.equal(0, count)
+    assert.strict.equal(0, count)
     s.close()
-    assert.equal(1, count)
+    assert.strict.equal(1, count)
     s.close()
-    assert.equal(1, count)
+    assert.strict.equal(1, count)
     done()
   })
 
   it('should accept a device option', function (done) {
     const s = new Speaker({ device: 'test' })
 
-    assert.equal(s.device, 'test')
+    assert.strict.equal(s.device, 'test')
 
     s.on('close', done)
     s.end(bufferAlloc(0))
@@ -124,7 +124,7 @@ describe('Speaker', function () {
       signed: true
     })
     speaker.once('error', (err) => {
-      assert.equal('invalid PCM format specified', err.message)
+      assert.strict.equal('invalid PCM format specified', err.message)
       done()
     })
     speaker.write('a')


### PR DESCRIPTION
This is actually no deadly necessary pull request. This mainly fixes bunch of deprecation warnings from Nan. I was in an attempt to fix a problem with new thread-workers in Node10 so I made these changes. But then found out that it wasn't the root of my problem nodejs/node#21481 otherwise the tests run, produces expected audio on my computer, all deps are bumped, with the readable dep removed in favor of the internal stream module provided by nodejs ecosystem. The old readable-stream module is mostly a polyfill for browser compatability as far as I understood it, bumping it to v3x caused errors with node-speaker.

Sorry about the noise, had to move this PR to another branch.