### PR TITLE
use Nan::GetCurrentEventLoop for threadsafety

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -65,7 +65,7 @@ NAN_METHOD(Write) {
 
   req->req.data = req;
 
-  uv_queue_work(uv_default_loop(), &req->req, write_async, (uv_after_work_cb)write_after);
+  uv_queue_work(Nan::GetCurrentEventLoop(), &req->req, write_async, (uv_after_work_cb)write_after);
 
   info.GetReturnValue().SetUndefined();
 }


### PR DESCRIPTION
Without this, nodejs segfaults when speaker is running in a seperate thread. This is the function used in the Nan examples

https://github.com/nodejs/nan/blob/139920eddc1afcf6590c218316b47070a4b9a1e8/test/cpp/asyncresource.cpp

I just noticed now, that with only this change, nodejs results in livelock (only when node-speaker is on another thread), so some part of my other PR is important here as well.