### PR TITLE
Updated definitions to resolve the TS1046 error.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { Writable, WritableOptions } from 'stream';
 
-namespace Speaker {
+export namespace Speaker {
     interface Options extends WritableOptions {
         readonly channels?: number;
         readonly bitDepth?: number;
@@ -25,7 +25,7 @@ namespace Speaker {
  *
  * @param opts options.
  */
-class Speaker extends Writable {
+export default class Speaker extends Writable {
     constructor(opts?: Speaker.Options);
 
     /**
@@ -55,5 +55,3 @@ class Speaker extends Writable {
      */
     public isSupported(format: number): boolean;
 }
-
-export = Speaker


### PR DESCRIPTION
Not sure if this is a result of recent TypeScript changes, since I've never used node-speaker with TypeScript before, but I'm getting this error message. I can confirm that my changes resolve that error and the library functions correctly.

```
node_modules/speaker/index.d.ts:3:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

3 namespace Speaker {
  ~~~~~~~~~
```