### PR TITLE
make flush argument optional to close function in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ class Speaker extends Writable {
      *
      * @param flush Defaults to `true`.
      */
-    public close(flush: boolean): string;
+    public close(flush?: boolean): string;
 
     /**
      * Returns the `MPG123_ENC_*` constant that corresponds to the given "format"


### PR DESCRIPTION
The type doc for the `close` method mentions that the `flush` argument defaults to `true`. This leads one to believe that the parameter is optional, however, the actual definition makes the parameter mandatory within TypeScript. This PR fixes that so that the parameter is fully optional to use or not, which also aligns with suggested usage I've seen of the method elsewhere in issues and the like.