### PR TITLE
Add support for selecting output audio device in Windows (win32 module)

### DIFF
--- a/deps/mpg123/src/output/win32.c
+++ b/deps/mpg123/src/output/win32.c
@@ -58,7 +58,22 @@ static int open_win32(struct audio_output_struct *ao)
 
     /* FIXME: real device enumeration by capabilities? */
     dev_id = WAVE_MAPPER;    /* probably does the same thing */
-    ao->device = "WaveMapper";
+    if (ao->device) {
+        /* Find device id of device with the same name as ao->device */
+        /* Device names from waveOutGetDevCaps are limited to 32  */ 
+        /* characters, so truncate ao->device for comparison */ 
+        ao->device[31] = '\0';
+        for (UINT i = 0; i < waveOutGetNumDevs(); ++i) {
+            WAVEOUTCAPS caps;
+            waveOutGetDevCaps(i, &caps, sizeof(WAVEOUTCAPS));
+            if (!strcmp(ao->device, caps.szPname)) {
+                dev_id = i;
+                break;
+            }
+        }
+    } else {
+        ao->device = "WaveMapper";
+    }
     /* FIXME: support for smth besides MPG123_ENC_SIGNED_16? */
     out_fmt.wFormatTag = WAVE_FORMAT_PCM;
     out_fmt.wBitsPerSample = 16;


### PR DESCRIPTION
Previously, the win32 output module would always use the default output device (`WAVE_MAPPER`). To support selecting non-default output devices, this PR will enumerate all output devices and pick the device with the same name as `ao->device`. The name comes from the szPname field in [WAVEOUTCAPS](https://docs.microsoft.com/en-us/previous-versions/dd743855(v=vs.85)) which is limited to 32 characters (including null sentinel). This means that to select an audio device such as `Speakers (High Definition Audio Device)`, `ao->device` must be truncated to the first 31 characters of that followed by the null byte.