### PR TITLE
Add `declare` modifiers to `index.d.ts`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { Writable, WritableOptions } from 'stream';
 
-namespace Speaker {
+declare namespace Speaker {
     interface Options extends WritableOptions {
         readonly channels?: number;
         readonly bitDepth?: number;
@@ -25,7 +25,7 @@ namespace Speaker {
  *
  * @param opts options.
  */
-class Speaker extends Writable {
+declare class Speaker extends Writable {
     constructor(opts?: Speaker.Options);
 
     /**


### PR DESCRIPTION
Fixes `TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.`