### PR TITLE
Update dead link with wayback machine

### DIFF
--- a/examples/sine.js
+++ b/examples/sine.js
@@ -2,7 +2,7 @@
 
 /**
  * Code adapted from:
- * http://blogs.msdn.com/b/dawate/archive/2009/06/24/intro-to-audio-programming-part-3-synthesizing-simple-wave-audio-using-c.aspx
+ * https://web.archive.org/web/20110816002016/http://blogs.msdn.com/b/dawate/archive/2009/06/24/intro-to-audio-programming-part-3-synthesizing-simple-wave-audio-using-c.aspx
  */
 
 const Readable = require('stream').Readable


### PR DESCRIPTION
the link http://blogs.msdn.com/b/dawate/archive/2009/06/24/intro-to-audio-programming-part-3-synthesizing-simple-wave-audio-using-c.aspx is dead. this PR replace the link with link from archive.org wayback machine.