### PR TITLE
feat: async flush and close

### DIFF
--- a/deps/mpg123/src/output/win32.c
+++ b/deps/mpg123/src/output/win32.c
@@ -223,9 +223,6 @@ static void flush_win32(struct audio_output_struct *ao)
     /* If WHDR_PREPARED is not set, this is (potentially) a partial buffer */
     if (!(hdr->dwFlags & WHDR_PREPARED))
     hdr->dwBufferLength = 0;
-
-    /* Finish processing the buffers */
-    drain_win32(ao);
 }
 
 /* output final buffer (if any) */

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ declare class Speaker extends Writable {
      *
      * @param flush Defaults to `true`.
      */
-    public close(flush: boolean): string;
+    public close(flush: boolean): void;
 
     /**
      * Returns the `MPG123_ENC_*` constant that corresponds to the given "format"


### PR DESCRIPTION
Make flush and close asynchronously, otherwise flush or close will block the main thread. But only Windows (win32) and MacOS (coreaudio) are tested, other backends are not tested (Don't have enough time and resource to test every backend, sorry). So this should be a BREAK_CHANGE, I just want to submit a PR for now and ask someone's advice.





