### PR TITLE
Fix CVE-2024-21526 by adding arg checks in binding.open 

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,12 @@ class Speaker extends Writable {
     this.blockAlign = this.bitDepth / 8 * this.channels
 
     // initialize the audio handle
-    // TODO: open async?
+    const chan = parseInt(this.channels || 2);
+    if ( Number.isNaN(chan) ) {
+      this.channels = 2;
+    } else {
+      this.channels = chan;
+    }
     this.audio_handle = binding.open(this.channels, this.sampleRate, format, this.device)
 
     this.emit('open')

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "speaker",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "(MIT AND LGPL-2.1-only)",
   "description": "Output PCM audio data to the speakers",
-  "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
+  "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net), @o0101 and Grok",
   "repository": "TooTallNate/node-speaker",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
# Fix CVE-2024-21526 by adding arg checks in binding.open and removing asserts

Re: https://github.com/advisories/GHSA-w5fc-gj3h-26rx

From the link:

> All versions of the package speaker are vulnerable to Denial of Service (DoS) when providing unexpected input types to the channels property of the Speaker object makes it possible to reach an assert macro. Exploiting this vulnerability can lead to a process crash.

The changes should prevent the process crashed vuln noted in the CVE.

- **Callback Info Check**: Replaced `assert(napi_get_cb_info...)` with a check for `napi_ok` and verified that `argc >= 4`. If this fails, an error is thrown and `NULL` is returned.

- **Memory Allocation**: Added a null check for `malloc` of `Speaker`. If allocation fails, a memory error is thrown.

- **Channels, Rate, Format**: Replaced `assert` calls with checks for `napi_get_value_int32`. Added input validation (e.g., `channels <= 0` or `rate <= 0` are considered invalid). On failure, the `speaker` is freed and an error is thrown.

- **Device String Handling**: Retained the `is_string` check. Replaced `assert` for `napi_get_value_string_utf8` with proper error handling. Added memory allocation checks for `speaker->device`, and ensured both `speaker` and `device` are freed on failure.

- **Handle Creation**: Combined checks for `napi_create_object` and `napi_wrap`. If either fails, resources are cleaned up and an error is thrown.

- **Cleanup**: Ensured all error paths properly free allocated memory (`speaker->device` and `speaker`) to prevent memory leaks.

- **Defensive Vibes**: Added thorough validation at every step. Invalid inputs or failures result in clear error messages to avoid crashes or undefined behavior.

- **JavaScript checks**: Also added a JS check for <Speaker>.channels before calling `binding.open` as another layer.

The fork this comes from also updates dependencies ([@dosyago-sec/node-speaker](https://github.com/dosyago-sec/node-speaker) - so it can be used in [BrowserBox - remote browser isolation and text client for the web](https://github.com/BrowserBox/BrowserBox)), but this is omitted here to avoid affecting existing tests and to minimize changes to the original repo for this PR.