### PR TITLE
Updating for CVE-2024-21526

### DIFF
--- a/src/binding.c
+++ b/src/binding.c
@@ -45,11 +45,26 @@ napi_value speaker_open(napi_env env, napi_callback_info info) {
   memset(speaker, 0, sizeof(Speaker));
   audio_output_t *ao = &speaker->ao;
 
-  assert(napi_get_value_int32(env, args[0], &ao->channels) == napi_ok); /* channels */
+  // assert(napi_get_value_int32(env, args[0], &ao->channels) == napi_ok); /* channels */
+  int32_t channels;
+  napi_status status = napi_get_value_int32(env, args[0], &channels);
+  if (status != napi_ok) {
+    napi_throw_type_error(env, NULL, "First argument must be an integer (channels)");
+    return NULL;
+  }
+ao->channels = channels;
   int32_t _rate;
-  assert(napi_get_value_int32(env, args[1], &_rate) == napi_ok); /* sample rate */
+  status = napi_get_value_int32(env, args[1], &_rate);
+  if (status != napi_ok) {
+    napi_throw_type_error(env, NULL, "Second argument must be an integer (sample rate)");
+    return NULL;
+  }
   ao->rate = _rate;
-  assert(napi_get_value_int32(env, args[2], &ao->format) == napi_ok); /* MPG123_ENC_* format */
+  status = napi_get_value_int32(env, args[2], &ao->format);
+  if (status != napi_ok) {
+    napi_throw_type_error(env, NULL, "Third argument must be an integer (format)");
+    return NULL;
+  }
 
   if (is_string(env, args[3])) {
     size_t device_string_size;


### PR DESCRIPTION
fix(napi): validate speaker_open args and improve error messages

Replace assert-based argument handling with explicit napi_status checks
Validate and set channels, sample rate, and format with clear type errors
Only read and assign device when the 4th arg is a string; ensure proper UTF-8 copy and NUL termination
Return early with ERR_OPEN on output init/open failures
Affected: binding.c

Tested: locally with sample program